### PR TITLE
feat/schemaorg-validation

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,0 +1,27 @@
+name: Create Release Notes
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  create-release-notes:
+    runs-on: ubuntu-latest
+    environment:
+      name: Release
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          name: ${{ github.event.release.tag_name }}
+          draft: false
+          prerelease: false
+          make_latest: 'true'
+          token: ${{ secrets.TESEO_TOKEN }}
+          body_path: ${{ github.workspace }}/.changes/${{ github.event.release.tag_name }}.md
+          generate_release_notes: false

--- a/schemaorg/article.go
+++ b/schemaorg/article.go
@@ -1,10 +1,8 @@
 package schemaorg
 
 import (
-	"context"
 	"fmt"
 	"html/template"
-	"log"
 
 	"github.com/a-h/templ"
 	"github.com/indaco/teseo"
@@ -89,6 +87,27 @@ func NewArticle(headline string, images []string, author *Person, publisher *Org
 	return article
 }
 
+// Validate checks if the Article has the recommended fields for SEO.
+// It returns a slice of warning messages for missing recommended fields.
+func (art *Article) Validate() []string {
+	var warnings []string
+
+	if art.Headline == "" {
+		warnings = append(warnings, "missing recommended field: headline")
+	}
+	if len(art.Image) == 0 {
+		warnings = append(warnings, "missing recommended field: image")
+	}
+	if art.DatePublished == "" {
+		warnings = append(warnings, "missing recommended field: datePublished")
+	}
+	if art.Author == nil && art.Publisher == nil {
+		warnings = append(warnings, "missing recommended field: author or publisher")
+	}
+
+	return warnings
+}
+
 // ToJsonLd converts the Article struct to a JSON-LD `templ.Component`.
 func (art *Article) ToJsonLd() templ.Component {
 	art.ensureDefaults()
@@ -98,12 +117,7 @@ func (art *Article) ToJsonLd() templ.Component {
 
 // ToGoHTMLJsonLd renders the Article struct as `template.HTML` value for Go's `html/template`.
 func (art *Article) ToGoHTMLJsonLd() (template.HTML, error) {
-	html, err := templ.ToGoHTML(context.Background(), art.ToJsonLd())
-	if err != nil {
-		log.Printf("failed to convert to html: %v", err)
-		return "", err
-	}
-	return html, nil
+	return teseo.RenderToHTML(art.ToJsonLd())
 }
 
 func (art *Article) ensureDefaults() {

--- a/schemaorg/article_test.go
+++ b/schemaorg/article_test.go
@@ -1,0 +1,141 @@
+package schemaorg
+
+import (
+	"testing"
+)
+
+func TestNewArticle_SetsFieldsAndDefaults(t *testing.T) {
+	author := &Person{Name: "Jane"}
+	publisher := &Organization{Name: "Example Publisher"}
+	article := NewArticle("Headline", []string{"img1.jpg"}, author, publisher, "2024-01-01", "2024-01-02", "desc")
+
+	if article.Type != "Article" {
+		t.Errorf("expected type Article, got %s", article.Type)
+	}
+	if article.Context != "https://schema.org" {
+		t.Errorf("expected schema.org context, got %s", article.Context)
+	}
+	if article.Headline != "Headline" {
+		t.Errorf("headline not set properly")
+	}
+	if article.Image[0] != "img1.jpg" {
+		t.Errorf("image not set properly")
+	}
+	if article.Author == nil || article.Author.Name != "Jane" {
+		t.Errorf("author not set properly")
+	}
+	if article.Publisher == nil || article.Publisher.Name != "Example Publisher" {
+		t.Errorf("publisher not set properly")
+	}
+}
+
+func TestArticle_EnsureDefaults(t *testing.T) {
+	art := &Article{}
+	art.ensureDefaults()
+
+	if art.Type != "Article" {
+		t.Errorf("expected default type 'Article', got %s", art.Type)
+	}
+	if art.Context != "https://schema.org" {
+		t.Errorf("expected default context 'https://schema.org', got %s", art.Context)
+	}
+}
+func TestArticle_Validate_AllFieldsPresent(t *testing.T) {
+	article := &Article{
+		Headline:      "Example Headline",
+		Image:         []string{"https://example.com/image.jpg"},
+		DatePublished: "2024-09-15",
+		Author:        &Person{Name: "Jane"},
+		Publisher:     &Organization{Name: "Example Org"},
+	}
+
+	warnings := article.Validate()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestArticle_Validate_MissingHeadline(t *testing.T) {
+	article := &Article{
+		Image:         []string{"https://example.com/image.jpg"},
+		DatePublished: "2024-09-15",
+		Author:        &Person{Name: "Jane"},
+	}
+
+	warnings := article.Validate()
+	if len(warnings) != 1 || warnings[0] != "missing recommended field: headline" {
+		t.Errorf("expected headline warning, got %v", warnings)
+	}
+}
+
+func TestArticle_Validate_MissingImage(t *testing.T) {
+	article := &Article{
+		Headline:      "Title",
+		DatePublished: "2024-09-15",
+		Author:        &Person{Name: "Jane"},
+	}
+
+	warnings := article.Validate()
+	if len(warnings) != 1 || warnings[0] != "missing recommended field: image" {
+		t.Errorf("expected image warning, got %v", warnings)
+	}
+}
+
+func TestArticle_Validate_MissingDatePublished(t *testing.T) {
+	article := &Article{
+		Headline: "Title",
+		Image:    []string{"https://example.com/image.jpg"},
+		Author:   &Person{Name: "Jane"},
+	}
+
+	warnings := article.Validate()
+	if len(warnings) != 1 || warnings[0] != "missing recommended field: datePublished" {
+		t.Errorf("expected datePublished warning, got %v", warnings)
+	}
+}
+
+func TestArticle_Validate_MissingAuthorAndPublisher(t *testing.T) {
+	article := &Article{
+		Headline:      "Title",
+		Image:         []string{"https://example.com/image.jpg"},
+		DatePublished: "2024-09-15",
+	}
+
+	warnings := article.Validate()
+	if len(warnings) != 1 || warnings[0] != "missing recommended field: author or publisher" {
+		t.Errorf("expected author or publisher warning, got %v", warnings)
+	}
+}
+
+func TestArticle_Validate_MultipleWarnings(t *testing.T) {
+	article := &Article{}
+
+	warnings := article.Validate()
+	expected := map[string]bool{
+		"missing recommended field: headline":            true,
+		"missing recommended field: image":               true,
+		"missing recommended field: datePublished":       true,
+		"missing recommended field: author or publisher": true,
+	}
+
+	if len(warnings) != len(expected) {
+		t.Errorf("expected %d warnings, got %d: %v", len(expected), len(warnings), warnings)
+	}
+
+	for _, w := range warnings {
+		if !expected[w] {
+			t.Errorf("unexpected warning: %s", w)
+		}
+	}
+}
+
+func TestArticle_ToGoHTMLJsonLd(t *testing.T) {
+	article := NewArticle("Test", nil, nil, nil, "", "", "")
+	html, err := article.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == "" {
+		t.Errorf("expected non-empty html output")
+	}
+}

--- a/schemaorg/breadcrumblist_test.go
+++ b/schemaorg/breadcrumblist_test.go
@@ -1,6 +1,7 @@
 package schemaorg
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -146,13 +147,7 @@ func TestBreadcrumbList_Validate(t *testing.T) {
 				return
 			}
 			for _, expectedWarning := range tt.expected {
-				found := false
-				for _, w := range warnings {
-					if w == expectedWarning {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(warnings, expectedWarning)
 				if !found {
 					t.Errorf("expected warning %q not found in %v", expectedWarning, warnings)
 				}

--- a/schemaorg/breadcrumblist_test.go
+++ b/schemaorg/breadcrumblist_test.go
@@ -1,0 +1,181 @@
+package schemaorg
+
+import (
+	"testing"
+)
+
+func TestNewBreadcrumbList_SetsDefaults(t *testing.T) {
+	items := []ListItem{
+		{Name: "Home", Item: "https://example.com", Position: 1},
+	}
+	bc := NewBreadcrumbList(items)
+
+	if bc.Type != "BreadcrumbList" {
+		t.Errorf("expected type BreadcrumbList, got %s", bc.Type)
+	}
+	if bc.Context != "https://schema.org" {
+		t.Errorf("expected context schema.org, got %s", bc.Context)
+	}
+	if bc.ItemListElement[0].Type != "ListItem" {
+		t.Errorf("expected ListItem type to be ListItem, got %s", bc.ItemListElement[0].Type)
+	}
+}
+
+func TestBreadcrumbList_EnsureDefaults(t *testing.T) {
+	bc := &BreadcrumbList{
+		ItemListElement: []ListItem{{}},
+	}
+	bc.ensureDefaults()
+
+	if bc.Context != "https://schema.org" {
+		t.Errorf("expected context to be set")
+	}
+	if bc.Type != "BreadcrumbList" {
+		t.Errorf("expected type to be set")
+	}
+	if bc.ItemListElement[0].Type != "ListItem" {
+		t.Errorf("expected item type to be ListItem")
+	}
+}
+
+func TestBreadcrumbList_ToGoHTMLJsonLd(t *testing.T) {
+	bc := NewBreadcrumbList([]ListItem{
+		{Name: "Home", Item: "https://example.com", Position: 1},
+	})
+	html, err := bc.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == "" {
+		t.Errorf("expected non-empty html")
+	}
+}
+
+func TestNewBreadcrumbListFromUrl(t *testing.T) {
+	bc, err := NewBreadcrumbListFromUrl("https://example.com/about/team")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(bc.ItemListElement) != 3 {
+		t.Errorf("expected 3 items, got %d", len(bc.ItemListElement))
+	}
+	if bc.ItemListElement[1].Name != "About" || bc.ItemListElement[2].Name != "Team" {
+		t.Errorf("unexpected breadcrumb names: %+v", bc.ItemListElement)
+	}
+}
+
+func TestNewBreadcrumbListFromUrl_Invalid(t *testing.T) {
+	_, err := NewBreadcrumbListFromUrl("http://[::1]:namedport")
+	if err == nil {
+		t.Errorf("expected error for invalid URL")
+	}
+}
+
+func TestBreadcrumbList_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		list     *BreadcrumbList
+		expected []string
+	}{
+		{
+			name: "valid breadcrumb",
+			list: NewBreadcrumbList([]ListItem{
+				{Name: "Home", Item: "https://example.com", Position: 1},
+			}),
+			expected: nil,
+		},
+		{
+			name: "missing item list",
+			list: &BreadcrumbList{},
+			expected: []string{
+				"BreadcrumbList should contain at least one item",
+			},
+		},
+		{
+			name: "item with missing name",
+			list: &BreadcrumbList{
+				ItemListElement: []ListItem{
+					{Item: "https://example.com", Position: 1},
+				},
+			},
+			expected: []string{
+				"ListItem at position 1 is missing a name",
+			},
+		},
+		{
+			name: "item with missing item URL",
+			list: &BreadcrumbList{
+				ItemListElement: []ListItem{
+					{Name: "Home", Position: 1},
+				},
+			},
+			expected: []string{
+				"ListItem at position 1 is missing a URL",
+			},
+		},
+		{
+			name: "item with missing name and item",
+			list: &BreadcrumbList{
+				ItemListElement: []ListItem{
+					{Position: 1},
+				},
+			},
+			expected: []string{
+				"ListItem at position 1 is missing a name",
+				"ListItem at position 1 is missing a URL",
+			},
+		},
+		{
+			name: "item with missing position",
+			list: &BreadcrumbList{
+				ItemListElement: []ListItem{
+					{Name: "Home", Item: "https://example.com", Position: 0},
+				},
+			},
+			expected: []string{
+				"ListItem at position 1 is missing a valid position",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := tt.list.Validate()
+			if len(warnings) != len(tt.expected) {
+				t.Errorf("expected %d warnings, got %d: %v", len(tt.expected), len(warnings), warnings)
+				return
+			}
+			for _, expectedWarning := range tt.expected {
+				found := false
+				for _, w := range warnings {
+					if w == expectedWarning {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected warning %q not found in %v", expectedWarning, warnings)
+				}
+			}
+		})
+	}
+}
+
+func TestToTitle(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"hello", "Hello"},
+		{"ßtraße", "ßtraße"},
+		{"123abc", "123abc"},
+	}
+
+	for _, tt := range tests {
+		result := toTitle(tt.input)
+		if result != tt.expected {
+			t.Errorf("toTitle(%q) = %q; want %q", tt.input, result, tt.expected)
+		}
+	}
+}

--- a/schemaorg/event.go
+++ b/schemaorg/event.go
@@ -1,10 +1,8 @@
 package schemaorg
 
 import (
-	"context"
 	"fmt"
 	"html/template"
-	"log"
 
 	"github.com/a-h/templ"
 	"github.com/indaco/teseo"
@@ -100,6 +98,22 @@ func NewEvent(name, description, startDate, endDate string, location *Place, org
 	return event
 }
 
+// Validate returns warnings for missing recommended Event fields.
+func (e *Event) Validate() []string {
+	var warnings []string
+
+	if e.Name == "" {
+		warnings = append(warnings, "missing recommended field: name")
+	}
+	if e.StartDate == "" {
+		warnings = append(warnings, "missing recommended field: startDate")
+	}
+	if e.Location == nil {
+		warnings = append(warnings, "missing recommended field: location")
+	}
+	return warnings
+}
+
 // ToJsonLd converts the Event struct to a JSON-LD `templ.Component`.
 func (e *Event) ToJsonLd() templ.Component {
 	e.ensureDefaults()
@@ -109,12 +123,7 @@ func (e *Event) ToJsonLd() templ.Component {
 
 // ToGoHTMLJsonLd renders the Event struct as `template.HTML` value for Go's `html/template`.
 func (e *Event) ToGoHTMLJsonLd() (template.HTML, error) {
-	html, err := templ.ToGoHTML(context.Background(), e.ToJsonLd())
-	if err != nil {
-		log.Printf("failed to convert to html: %v", err)
-		return "", err
-	}
-	return html, nil
+	return teseo.RenderToHTML(e.ToJsonLd())
 }
 
 // ensureDefaults sets default values for Event and its nested objects if they are not already set.

--- a/schemaorg/event_test.go
+++ b/schemaorg/event_test.go
@@ -1,0 +1,172 @@
+package schemaorg
+
+import (
+	"testing"
+)
+
+func TestNewEvent_SetsDefaults(t *testing.T) {
+	event := NewEvent(
+		"Sample Event", "desc", "2024-01-01T10:00:00", "2024-01-01T12:00:00",
+		&Place{Name: "Venue"}, nil, nil, nil, "", "", nil,
+	)
+
+	if event.Type != "Event" {
+		t.Errorf("expected type to be Event, got %s", event.Type)
+	}
+	if event.Context != "https://schema.org" {
+		t.Errorf("expected context to be schema.org, got %s", event.Context)
+	}
+	if event.Location.Type != "Place" {
+		t.Errorf("expected nested Place type to be set")
+	}
+}
+
+func TestEvent_EnsureDefaults(t *testing.T) {
+	e := &Event{}
+	e.ensureDefaults()
+	if e.Type != "Event" {
+		t.Errorf("expected default type Event, got %s", e.Type)
+	}
+	if e.Context != "https://schema.org" {
+		t.Errorf("expected default context https://schema.org, got %s", e.Context)
+	}
+}
+
+func TestEvent_EnsureDefaults_WithNestedValues(t *testing.T) {
+	org := &Organization{}
+	per := &Person{}
+	offer := &Offer{}
+
+	event := &Event{
+		Organizer: org,
+		Performer: per,
+		Offers:    offer,
+	}
+
+	event.ensureDefaults()
+
+	if org.Context != "https://schema.org" {
+		t.Errorf("expected Organizer context to be schema.org, got %s", org.Context)
+	}
+	if org.Type != "Organization" {
+		t.Errorf("expected Organizer type to be Organization, got %s", org.Type)
+	}
+
+	if per.Context != "https://schema.org" {
+		t.Errorf("expected Performer context to be schema.org, got %s", per.Context)
+	}
+	if per.Type != "Person" {
+		t.Errorf("expected Performer type to be Person, got %s", per.Type)
+	}
+
+	if offer.Type != "Offer" {
+		t.Errorf("expected Offer type to be Offer, got %s", offer.Type)
+	}
+}
+
+func TestEvent_Validate_AllGood(t *testing.T) {
+	e := &Event{
+		Name:      "My Event",
+		StartDate: "2024-01-01T10:00:00",
+		Location:  &Place{Name: "Venue"},
+	}
+	warnings := e.Validate()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestEvent_Validate_MissingName(t *testing.T) {
+	e := &Event{
+		StartDate: "2024-01-01T10:00:00",
+		Location:  &Place{Name: "Venue"},
+	}
+	w := e.Validate()
+	if len(w) != 1 || w[0] != "missing recommended field: name" {
+		t.Errorf("expected name warning, got %v", w)
+	}
+}
+
+func TestEvent_Validate_MissingStartDate(t *testing.T) {
+	e := &Event{
+		Name:     "My Event",
+		Location: &Place{Name: "Venue"},
+	}
+	w := e.Validate()
+	if len(w) != 1 || w[0] != "missing recommended field: startDate" {
+		t.Errorf("expected startDate warning, got %v", w)
+	}
+}
+
+func TestEvent_Validate_MissingLocation(t *testing.T) {
+	e := &Event{
+		Name:      "My Event",
+		StartDate: "2024-01-01T10:00:00",
+	}
+	w := e.Validate()
+	if len(w) != 1 || w[0] != "missing recommended field: location" {
+		t.Errorf("expected location warning, got %v", w)
+	}
+}
+
+func TestEvent_Validate_AllMissing(t *testing.T) {
+	e := &Event{}
+	expected := map[string]bool{
+		"missing recommended field: name":      true,
+		"missing recommended field: startDate": true,
+		"missing recommended field: location":  true,
+	}
+	warnings := e.Validate()
+	if len(warnings) != len(expected) {
+		t.Errorf("expected %d warnings, got %d", len(expected), len(warnings))
+	}
+	for _, w := range warnings {
+		if !expected[w] {
+			t.Errorf("unexpected warning: %s", w)
+		}
+	}
+}
+
+func TestEvent_ToGoHTMLJsonLd(t *testing.T) {
+	e := NewEvent("Test Event", "", "2024-01-01T10:00", "", &Place{Name: "Venue"}, nil, nil, nil, "", "", nil)
+	html, err := e.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == "" {
+		t.Errorf("expected non-empty HTML output")
+	}
+}
+
+func TestPlace_EnsureDefaults_WithAddressAndGeo(t *testing.T) {
+	addr := &PostalAddress{}
+	geo := &GeoCoordinates{}
+	p := &Place{
+		Address: addr,
+		Geo:     geo,
+	}
+	p.ensureDefaults()
+
+	if addr.Type != "PostalAddress" {
+		t.Errorf("expected Address.Type to be PostalAddress")
+	}
+	if geo.Type != "GeoCoordinates" {
+		t.Errorf("expected Geo.Type to be GeoCoordinates")
+	}
+}
+
+func TestPlace_EnsureDefaults_NilAddressAndGeo(t *testing.T) {
+	p := &Place{
+		Address: nil,
+		Geo:     nil,
+	}
+	p.ensureDefaults()
+
+	if p.Context != "https://schema.org" {
+		t.Errorf("expected Context to be https://schema.org, got %s", p.Context)
+	}
+	if p.Type != "Place" {
+		t.Errorf("expected Type to be Place, got %s", p.Type)
+	}
+	// This test ensures no panic and default values are set even if Address and Geo are nil.
+}

--- a/schemaorg/faq_page_test.go
+++ b/schemaorg/faq_page_test.go
@@ -1,6 +1,9 @@
 package schemaorg
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestNewFAQPage_Defaults(t *testing.T) {
 	q := NewQuestion("What is Go?", NewAnswer("A programming language"))
@@ -116,13 +119,7 @@ func TestFAQPage_Validate(t *testing.T) {
 				return
 			}
 			for _, expected := range tt.expected {
-				found := false
-				for _, w := range warnings {
-					if w == expected {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(warnings, expected)
 				if !found {
 					t.Errorf("missing expected warning: %s", expected)
 				}

--- a/schemaorg/faq_page_test.go
+++ b/schemaorg/faq_page_test.go
@@ -1,0 +1,132 @@
+package schemaorg
+
+import "testing"
+
+func TestNewFAQPage_Defaults(t *testing.T) {
+	q := NewQuestion("What is Go?", NewAnswer("A programming language"))
+	faq := NewFAQPage([]*Question{q})
+	if faq.Context != "https://schema.org" {
+		t.Errorf("expected default context")
+	}
+	if faq.Type != "FAQPage" {
+		t.Errorf("expected default type")
+	}
+}
+
+func TestFAQPage_EnsureDefaults(t *testing.T) {
+	q := &Question{
+		AcceptedAnswer: &Answer{},
+	}
+	fp := &FAQPage{
+		MainEntity: []*Question{q},
+	}
+	fp.ensureDefaults()
+
+	if fp.Context != "https://schema.org" {
+		t.Errorf("expected default context")
+	}
+	if fp.Type != "FAQPage" {
+		t.Errorf("expected default type")
+	}
+	if q.Type != "Question" {
+		t.Errorf("expected default type for Question")
+	}
+	if q.AcceptedAnswer.Type != "Answer" {
+		t.Errorf("expected default type for Answer")
+	}
+}
+
+func TestFAQPage_ToGoHTMLJsonLd(t *testing.T) {
+	fp := NewFAQPage([]*Question{
+		NewQuestion("Q", NewAnswer("A")),
+	})
+	html, err := fp.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == "" {
+		t.Errorf("expected non-empty HTML")
+	}
+}
+
+func TestFAQPage_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		page     *FAQPage
+		expected []string
+	}{
+		{
+			name: "valid page",
+			page: NewFAQPage([]*Question{
+				NewQuestion("Q", NewAnswer("A")),
+			}),
+			expected: nil,
+		},
+		{
+			name: "missing main entity",
+			page: &FAQPage{},
+			expected: []string{
+				"FAQPage should contain at least one question",
+			},
+		},
+		{
+			name: "missing question name",
+			page: NewFAQPage([]*Question{
+				NewQuestion("", NewAnswer("A")),
+			}),
+			expected: []string{
+				"Question 1 is missing a name",
+			},
+		},
+		{
+			name: "missing accepted answer",
+			page: NewFAQPage([]*Question{
+				{Name: "Q"},
+			}),
+			expected: []string{
+				"Question 1 is missing an accepted answer",
+			},
+		},
+		{
+			name: "empty answer text",
+			page: NewFAQPage([]*Question{
+				NewQuestion("Q", &Answer{Text: ""}),
+			}),
+			expected: []string{
+				"Answer for question 1 is missing text",
+			},
+		},
+		{
+			name: "multiple warnings",
+			page: NewFAQPage([]*Question{
+				{},
+			}),
+			expected: []string{
+				"Question 1 is missing a name",
+				"Question 1 is missing an accepted answer",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := tt.page.Validate()
+			if len(warnings) != len(tt.expected) {
+				t.Errorf("expected %d warnings, got %d: %v", len(tt.expected), len(warnings), warnings)
+				return
+			}
+			for _, expected := range tt.expected {
+				found := false
+				for _, w := range warnings {
+					if w == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("missing expected warning: %s", expected)
+				}
+			}
+		})
+	}
+}

--- a/schemaorg/local_business.go
+++ b/schemaorg/local_business.go
@@ -1,10 +1,8 @@
 package schemaorg
 
 import (
-	"context"
 	"fmt"
 	"html/template"
-	"log"
 
 	"github.com/a-h/templ"
 	"github.com/indaco/teseo"
@@ -99,6 +97,26 @@ func NewLocalBusiness(name string, description string, url string, telephone str
 	return localBusiness
 }
 
+// Validate returns a list of recommended validation warnings for schema.org LocalBusiness.
+func (lb *LocalBusiness) Validate() []string {
+	var warnings []string
+
+	if lb.Name == "" {
+		warnings = append(warnings, "missing recommended field: name")
+	}
+	if lb.Address == nil {
+		warnings = append(warnings, "missing recommended field: address")
+	}
+	if lb.Telephone == "" {
+		warnings = append(warnings, "missing recommended field: telephone")
+	}
+	if lb.Description == "" {
+		warnings = append(warnings, "missing recommended field: description")
+	}
+
+	return warnings
+}
+
 // ToJsonLd converts the LocalBusiness struct to a JSON-LD `templ.Component`.
 func (lb *LocalBusiness) ToJsonLd() templ.Component {
 	lb.ensureDefaults()
@@ -108,12 +126,7 @@ func (lb *LocalBusiness) ToJsonLd() templ.Component {
 
 // ToGoHTMLJsonLd renders the LocalBusiness struct as `template.HTML` value for Go's `html/template`.
 func (lb *LocalBusiness) ToGoHTMLJsonLd() (template.HTML, error) {
-	html, err := templ.ToGoHTML(context.Background(), lb.ToJsonLd())
-	if err != nil {
-		log.Printf("failed to convert to html: %v", err)
-		return "", err
-	}
-	return html, nil
+	return teseo.RenderToHTML(lb.ToJsonLd())
 }
 
 // ensureDefaults sets default values for LocalBusiness and its nested objects if they are not already set.

--- a/schemaorg/local_business_test.go
+++ b/schemaorg/local_business_test.go
@@ -1,0 +1,116 @@
+package schemaorg
+
+import (
+	"testing"
+)
+
+func TestNewLocalBusiness_SetsFieldsAndDefaults(t *testing.T) {
+	lb := NewLocalBusiness(
+		"Business Name",
+		"Great service",
+		"https://example.com",
+		"+1-800-555-1234",
+		&ImageObject{URL: "https://example.com/logo.png"},
+		&PostalAddress{StreetAddress: "123 St", AddressLocality: "Town"},
+		[]string{"Mo-Fr 09:00-17:00"},
+		&GeoCoordinates{Latitude: 45.0, Longitude: 12.0},
+		&AggregateRating{RatingValue: 4.5, ReviewCount: 100},
+		[]*Review{{ReviewBody: "Awesome!"}},
+	)
+
+	if lb.Type != "LocalBusiness" {
+		t.Errorf("expected type to be LocalBusiness, got %s", lb.Type)
+	}
+	if lb.Context != "https://schema.org" {
+		t.Errorf("expected context to be schema.org, got %s", lb.Context)
+	}
+	if lb.Logo == nil || lb.Logo.Type != "ImageObject" {
+		t.Errorf("expected logo with type ImageObject")
+	}
+	if lb.Address == nil || lb.Address.Type != "PostalAddress" {
+		t.Errorf("expected address with type PostalAddress")
+	}
+	if lb.Geo == nil || lb.Geo.Type != "GeoCoordinates" {
+		t.Errorf("expected geo with type GeoCoordinates")
+	}
+	if lb.AggregateRating == nil || lb.AggregateRating.Type != "AggregateRating" {
+		t.Errorf("expected aggregateRating with type AggregateRating")
+	}
+	if len(lb.Review) != 1 || lb.Review[0].Type != "Review" {
+		t.Errorf("expected review with type Review")
+	}
+}
+
+func TestLocalBusiness_EnsureDefaults_NestedNilSafe(t *testing.T) {
+	lb := &LocalBusiness{}
+	lb.ensureDefaults()
+
+	if lb.Type != "LocalBusiness" {
+		t.Errorf("expected default type LocalBusiness")
+	}
+	if lb.Context != "https://schema.org" {
+		t.Errorf("expected default context schema.org")
+	}
+}
+
+func TestLocalBusiness_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		lb       *LocalBusiness
+		expected []string
+	}{
+		{
+			name: "valid",
+			lb: &LocalBusiness{
+				Name:        "Shop",
+				Address:     &PostalAddress{},
+				Telephone:   "+1-800",
+				Description: "desc",
+			},
+			expected: nil,
+		},
+		{
+			name:     "all missing",
+			lb:       &LocalBusiness{},
+			expected: []string{"missing recommended field: name", "missing recommended field: address", "missing recommended field: telephone", "missing recommended field: description"},
+		},
+		{
+			name:     "missing address",
+			lb:       &LocalBusiness{Name: "x", Telephone: "y", Description: "z"},
+			expected: []string{"missing recommended field: address"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := tt.lb.Validate()
+			if len(warnings) != len(tt.expected) {
+				t.Errorf("expected %d warnings, got %d: %v", len(tt.expected), len(warnings), warnings)
+				return
+			}
+			for _, expected := range tt.expected {
+				found := false
+				for _, got := range warnings {
+					if expected == got {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected warning %q not found in %v", expected, warnings)
+				}
+			}
+		})
+	}
+}
+
+func TestLocalBusiness_ToGoHTMLJsonLd(t *testing.T) {
+	lb := NewLocalBusiness("My Shop", "", "", "", nil, nil, nil, nil, nil, nil)
+	html, err := lb.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == "" {
+		t.Errorf("expected non-empty html")
+	}
+}

--- a/schemaorg/local_business_test.go
+++ b/schemaorg/local_business_test.go
@@ -1,6 +1,7 @@
 package schemaorg
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -89,13 +90,7 @@ func TestLocalBusiness_Validate(t *testing.T) {
 				return
 			}
 			for _, expected := range tt.expected {
-				found := false
-				for _, got := range warnings {
-					if expected == got {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(warnings, expected)
 				if !found {
 					t.Errorf("expected warning %q not found in %v", expected, warnings)
 				}

--- a/schemaorg/organization.go
+++ b/schemaorg/organization.go
@@ -1,5 +1,13 @@
 package schemaorg
 
+import (
+	"fmt"
+	"html/template"
+
+	"github.com/a-h/templ"
+	"github.com/indaco/teseo"
+)
+
 // Organization represents a Schema.org Organization object.
 // For more details about the meaning of the properties, see:https://schema.org/Organization
 //
@@ -44,6 +52,47 @@ package schemaorg
 // 		"description": "This is an example organization"
 // 	}
 
+// Organization represents a Schema.org Organization object
+// For more details about the meaning of the properties see: https://schema.org/Organization
+type Organization struct {
+	Context       string         `json:"@context"`
+	Type          string         `json:"@type"`
+	Name          string         `json:"name,omitempty"`
+	URL           string         `json:"url,omitempty"`
+	Logo          *ImageObject   `json:"logo,omitempty"`
+	ContactPoints []ContactPoint `json:"contactPoint,omitempty"`
+	SameAs        []string       `json:"sameAs,omitempty"`
+}
+
+// Validate checks for recommended fields in Organization.
+func (org *Organization) Validate() []string {
+	var warnings []string
+
+	if org.Name == "" {
+		warnings = append(warnings, "missing recommended field: name")
+	}
+	if org.URL == "" {
+		warnings = append(warnings, "missing recommended field: url")
+	}
+	if org.Logo == nil || org.Logo.URL == "" {
+		warnings = append(warnings, "missing recommended field: logo.url")
+	}
+
+	return warnings
+}
+
+// ToJsonLd converts the Organization struct to a JSON-LD `templ.Component`.
+func (org *Organization) ToJsonLd() templ.Component {
+	org.ensureDefaults()
+	id := fmt.Sprintf("%s-%s", "org", teseo.GenerateUniqueKey())
+	return templ.JSONScript(id, org).WithType("application/ld+json")
+}
+
+// ToGoHTMLJsonLd renders the Organization struct as `template.HTML` value for Go's `html/template`.
+func (org *Organization) ToGoHTMLJsonLd() (template.HTML, error) {
+	return teseo.RenderToHTML(org.ToJsonLd())
+}
+
 // NewOrganization initializes an Organization with default context and type.
 func NewOrganization(name string, url string, logoURL string, contactPoints []ContactPoint, sameAs []string) *Organization {
 	org := &Organization{
@@ -58,4 +107,18 @@ func NewOrganization(name string, url string, logoURL string, contactPoints []Co
 	}
 	org.ensureDefaults()
 	return org
+}
+
+func (org *Organization) ensureDefaults() {
+	if org.Context == "" {
+		org.Context = "https://schema.org"
+	}
+
+	if org.Type == "" {
+		org.Type = "Organization"
+	}
+
+	if org.Logo != nil {
+		org.Logo.ensureDefaults()
+	}
 }

--- a/schemaorg/organization_test.go
+++ b/schemaorg/organization_test.go
@@ -1,0 +1,143 @@
+package schemaorg
+
+import (
+	"html/template"
+	"testing"
+)
+
+func TestNewOrganization_SetsFieldsAndDefaults(t *testing.T) {
+	org := NewOrganization(
+		"Example Organization",
+		"https://example.com",
+		"https://example.com/logo.png",
+		[]ContactPoint{{Telephone: "+1-800-1234", ContactType: "customer support"}},
+		[]string{"https://twitter.com/example"},
+	)
+
+	if org.Context != "https://schema.org" {
+		t.Errorf("expected context to be schema.org, got %s", org.Context)
+	}
+	if org.Type != "Organization" {
+		t.Errorf("expected type to be Organization, got %s", org.Type)
+	}
+	if org.Name != "Example Organization" {
+		t.Errorf("name not set correctly")
+	}
+	if org.URL != "https://example.com" {
+		t.Errorf("URL not set correctly")
+	}
+	if org.Logo == nil || org.Logo.URL != "https://example.com/logo.png" || org.Logo.Type != "ImageObject" {
+		t.Errorf("Logo not set correctly")
+	}
+	if len(org.ContactPoints) != 1 || org.ContactPoints[0].Telephone != "+1-800-1234" {
+		t.Errorf("ContactPoints not set correctly")
+	}
+	if len(org.SameAs) != 1 || org.SameAs[0] != "https://twitter.com/example" {
+		t.Errorf("SameAs not set correctly")
+	}
+}
+
+func TestOrganization_EnsureDefaults_NilSafe(t *testing.T) {
+	org := &Organization{}
+	org.ensureDefaults()
+
+	if org.Context != "https://schema.org" {
+		t.Errorf("expected context to be schema.org, got %s", org.Context)
+	}
+	if org.Type != "Organization" {
+		t.Errorf("expected type to be Organization, got %s", org.Type)
+	}
+}
+
+func TestOrganization_Validate_AllGood(t *testing.T) {
+	org := &Organization{
+		Name: "Example Org",
+		URL:  "https://example.com",
+		Logo: &ImageObject{URL: "https://example.com/logo.jpg"},
+	}
+	warnings := org.Validate()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestOrganization_Validate_MissingName(t *testing.T) {
+	org := &Organization{
+		URL:  "https://example.com",
+		Logo: &ImageObject{URL: "https://example.com/logo.jpg"},
+	}
+	warnings := org.Validate()
+	want := "missing recommended field: name"
+	if len(warnings) != 1 || warnings[0] != want {
+		t.Errorf("expected [%s], got %v", want, warnings)
+	}
+}
+
+func TestOrganization_Validate_MissingURL(t *testing.T) {
+	org := &Organization{
+		Name: "Org",
+		Logo: &ImageObject{URL: "https://example.com/logo.jpg"},
+	}
+	warnings := org.Validate()
+	want := "missing recommended field: url"
+	if len(warnings) != 1 || warnings[0] != want {
+		t.Errorf("expected [%s], got %v", want, warnings)
+	}
+}
+
+func TestOrganization_Validate_MissingLogo(t *testing.T) {
+	org := &Organization{
+		Name: "Org",
+		URL:  "https://example.com",
+	}
+	warnings := org.Validate()
+	want := "missing recommended field: logo.url"
+	if len(warnings) != 1 || warnings[0] != want {
+		t.Errorf("expected [%s], got %v", want, warnings)
+	}
+}
+
+func TestOrganization_Validate_EmptyLogoURL(t *testing.T) {
+	org := &Organization{
+		Name: "Org",
+		URL:  "https://example.com",
+		Logo: &ImageObject{URL: ""},
+	}
+	warnings := org.Validate()
+	want := "missing recommended field: logo.url"
+	if len(warnings) != 1 || warnings[0] != want {
+		t.Errorf("expected [%s], got %v", want, warnings)
+	}
+}
+
+func TestOrganization_Validate_MultipleWarnings(t *testing.T) {
+	org := &Organization{}
+	warnings := org.Validate()
+
+	expected := map[string]bool{
+		"missing recommended field: name":     true,
+		"missing recommended field: url":      true,
+		"missing recommended field: logo.url": true,
+	}
+
+	if len(warnings) != len(expected) {
+		t.Errorf("expected %d warnings, got %d: %v", len(expected), len(warnings), warnings)
+	}
+
+	for _, w := range warnings {
+		if !expected[w] {
+			t.Errorf("unexpected warning: %s", w)
+		}
+	}
+}
+
+func TestOrganization_ToGoHTMLJsonLd(t *testing.T) {
+	org := NewOrganization("Test Org", "https://example.org", "https://example.org/logo.jpg", nil, nil)
+	html, err := org.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == template.HTML("") {
+		t.Errorf("expected non-empty HTML")
+	}
+}

--- a/schemaorg/person.go
+++ b/schemaorg/person.go
@@ -54,6 +54,26 @@ import (
 // 		"worksFor": {"@type": "Organization", "name": "Example Company"}
 // 	}
 
+// Person represents a Schema.org Person object
+// For more details about the meaning of the properties see: https://schema.org/Person
+type Person struct {
+	Context     string         `json:"@context"`
+	Type        string         `json:"@type"`
+	Name        string         `json:"name,omitempty"`
+	URL         string         `json:"url,omitempty"`
+	Email       string         `json:"email,omitempty"`
+	Image       *ImageObject   `json:"image,omitempty"`
+	JobTitle    string         `json:"jobTitle,omitempty"`
+	WorksFor    *Organization  `json:"worksFor,omitempty"`
+	SameAs      []string       `json:"sameAs,omitempty"`
+	Gender      string         `json:"gender,omitempty"`
+	BirthDate   string         `json:"birthDate,omitempty"`
+	Nationality string         `json:"nationality,omitempty"`
+	Telephone   string         `json:"telephone,omitempty"`
+	Address     *PostalAddress `json:"address,omitempty"`
+	Affiliation *Organization  `json:"affiliation,omitempty"`
+}
+
 // PostalAddress represents a Schema.org PostalAddress object
 type PostalAddress struct {
 	Type            string `json:"@type"`
@@ -92,6 +112,25 @@ func NewPerson(name string, url string, email string, image *ImageObject, jobTit
 	return person
 }
 
+// Validate checks for recommended or required fields in Person.
+func (p *Person) Validate() []string {
+	var warnings []string
+
+	if p.Name == "" {
+		warnings = append(warnings, "missing recommended field: name")
+	}
+
+	if p.Email == "" {
+		warnings = append(warnings, "missing recommended field: email")
+	}
+
+	if p.JobTitle == "" {
+		warnings = append(warnings, "missing recommended field: jobTitle")
+	}
+
+	return warnings
+}
+
 // ToJsonLd converts the Person struct to a JSON-LD `templ.Component`.
 func (p *Person) ToJsonLd() templ.Component {
 	p.ensureDefaults()
@@ -101,12 +140,7 @@ func (p *Person) ToJsonLd() templ.Component {
 
 // ToGoHTMLJsonLd renders the Person struct as `template.HTML` value for Go's `html/template`.
 func (p *Person) ToGoHTMLJsonLd() (template.HTML, error) {
-	html, err := templ.ToGoHTML(context.Background(), p.ToJsonLd())
-	if err != nil {
-		log.Printf("failed to convert to html: %v", err)
-		return "", err
-	}
-	return html, nil
+	return teseo.RenderToHTML(p.ToJsonLd())
 }
 
 // ensureDefaults sets default values for Person and its nested objects if they are not already set.

--- a/schemaorg/person.go
+++ b/schemaorg/person.go
@@ -1,10 +1,8 @@
 package schemaorg
 
 import (
-	"context"
 	"fmt"
 	"html/template"
-	"log"
 
 	"github.com/a-h/templ"
 	"github.com/indaco/teseo"

--- a/schemaorg/person_test.go
+++ b/schemaorg/person_test.go
@@ -1,0 +1,134 @@
+package schemaorg
+
+import (
+	"testing"
+)
+
+func TestNewPerson_SetsFieldsAndDefaults(t *testing.T) {
+	org := &Organization{Name: "Example Company"}
+	img := &ImageObject{URL: "https://img.com/avatar.jpg"}
+
+	person := NewPerson("Jane Doe", "https://example.com", "jane@example.com", img, "Engineer", org, []string{"https://twitter.com/jane"}, "Female", "1990-01-01", "US", "+123456", nil, nil)
+
+	if person.Type != "Person" {
+		t.Errorf("expected type Person, got %s", person.Type)
+	}
+	if person.Context != "https://schema.org" {
+		t.Errorf("expected context schema.org, got %s", person.Context)
+	}
+	if person.Image.Type != "ImageObject" {
+		t.Errorf("expected ImageObject type")
+	}
+	if person.WorksFor.Type != "Organization" {
+		t.Errorf("expected Organization type")
+	}
+}
+
+func TestPerson_EnsureDefaults_WithNestedValues(t *testing.T) {
+	image := &ImageObject{}
+	worksFor := &Organization{}
+	address := &PostalAddress{}
+	affiliation := &Organization{}
+
+	person := &Person{
+		Image:       image,
+		WorksFor:    worksFor,
+		Address:     address,
+		Affiliation: affiliation,
+	}
+
+	person.ensureDefaults()
+
+	if person.Context != "https://schema.org" {
+		t.Errorf("expected Person context to be schema.org, got %s", person.Context)
+	}
+	if person.Type != "Person" {
+		t.Errorf("expected Person type to be Person, got %s", person.Type)
+	}
+
+	if image.Type != "ImageObject" {
+		t.Errorf("expected Image type to be ImageObject, got %s", image.Type)
+	}
+
+	if worksFor.Context != "https://schema.org" {
+		t.Errorf("expected WorksFor context to be schema.org, got %s", worksFor.Context)
+	}
+	if worksFor.Type != "Organization" {
+		t.Errorf("expected WorksFor type to be Organization, got %s", worksFor.Type)
+	}
+
+	if address.Type != "PostalAddress" {
+		t.Errorf("expected Address type to be PostalAddress, got %s", address.Type)
+	}
+
+	if affiliation.Context != "https://schema.org" {
+		t.Errorf("expected Affiliation context to be schema.org, got %s", affiliation.Context)
+	}
+	if affiliation.Type != "Organization" {
+		t.Errorf("expected Affiliation type to be Organization, got %s", affiliation.Type)
+	}
+}
+
+func TestPerson_ToGoHTMLJsonLd(t *testing.T) {
+	person := NewPerson("Jane", "", "", nil, "", nil, nil, "", "", "", "", nil, nil)
+
+	html, err := person.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == "" {
+		t.Errorf("expected non-empty HTML")
+	}
+}
+
+func TestPerson_Validate_AllGood(t *testing.T) {
+	p := &Person{
+		Name:     "John",
+		Email:    "john@example.com",
+		JobTitle: "Engineer",
+	}
+	warnings := p.Validate()
+	if len(warnings) > 0 {
+		t.Errorf("expected no warnings, got: %v", warnings)
+	}
+}
+
+func TestPerson_Validate_MissingFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		person   *Person
+		expected []string
+	}{
+		{
+			name:     "missing all",
+			person:   &Person{},
+			expected: []string{"missing recommended field: name", "missing recommended field: email", "missing recommended field: jobTitle"},
+		},
+		{
+			name:     "missing email and job title",
+			person:   &Person{Name: "Jane"},
+			expected: []string{"missing recommended field: email", "missing recommended field: jobTitle"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.person.Validate()
+			if len(got) != len(tt.expected) {
+				t.Fatalf("expected %d warnings, got %d: %v", len(tt.expected), len(got), got)
+			}
+			for _, expected := range tt.expected {
+				found := false
+				for _, w := range got {
+					if w == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected warning %q not found in %v", expected, got)
+				}
+			}
+		})
+	}
+}

--- a/schemaorg/person_test.go
+++ b/schemaorg/person_test.go
@@ -1,6 +1,7 @@
 package schemaorg
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -118,13 +119,7 @@ func TestPerson_Validate_MissingFields(t *testing.T) {
 				t.Fatalf("expected %d warnings, got %d: %v", len(tt.expected), len(got), got)
 			}
 			for _, expected := range tt.expected {
-				found := false
-				for _, w := range got {
-					if w == expected {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(got, expected)
 				if !found {
 					t.Errorf("expected warning %q not found in %v", expected, got)
 				}

--- a/schemaorg/product.go
+++ b/schemaorg/product.go
@@ -1,10 +1,8 @@
 package schemaorg
 
 import (
-	"context"
 	"fmt"
 	"html/template"
-	"log"
 
 	"github.com/a-h/templ"
 	"github.com/indaco/teseo"
@@ -139,12 +137,7 @@ func (p *Product) ToJsonLd() templ.Component {
 
 // ToGoHTMLJsonLd renders the Product struct as `template.HTML` value for Go's `html/template`.
 func (p *Product) ToGoHTMLJsonLd() (template.HTML, error) {
-	html, err := templ.ToGoHTML(context.Background(), p.ToJsonLd())
-	if err != nil {
-		log.Printf("failed to convert to html: %v", err)
-		return "", err
-	}
-	return html, nil
+	return teseo.RenderToHTML(p.ToJsonLd())
 }
 
 // ensureDefaults sets default values for Product and its nested objects if they are not already set.

--- a/schemaorg/product_test.go
+++ b/schemaorg/product_test.go
@@ -1,0 +1,133 @@
+package schemaorg
+
+import (
+	"testing"
+)
+
+func TestNewProduct_SetsFieldsAndDefaults(t *testing.T) {
+	brand := &Brand{Name: "Example Brand"}
+	offer := &Offer{Price: "29.99", PriceCurrency: "USD"}
+	agg := &AggregateRating{RatingValue: 4.5, ReviewCount: 10}
+	review := &Review{ReviewBody: "Good product", Author: &Person{Name: "Alice"}, ReviewRating: &Rating{RatingValue: 5}}
+
+	product := NewProduct(
+		"Example Product",
+		"Description",
+		[]string{"https://example.com/image.jpg"},
+		"SKU123",
+		brand,
+		offer,
+		"Electronics",
+		agg,
+		[]*Review{review},
+	)
+
+	if product.Context != "https://schema.org" {
+		t.Errorf("expected context schema.org, got %s", product.Context)
+	}
+	if product.Type != "Product" {
+		t.Errorf("expected type Product, got %s", product.Type)
+	}
+	if product.Brand == nil || product.Brand.Type != "Brand" {
+		t.Errorf("expected brand type Brand, got %v", product.Brand)
+	}
+	if product.Offers == nil || product.Offers.Type != "Offer" {
+		t.Errorf("expected offer type Offer, got %v", product.Offers)
+	}
+	if product.AggregateRating == nil || product.AggregateRating.Type != "AggregateRating" {
+		t.Errorf("expected aggregateRating type AggregateRating, got %v", product.AggregateRating)
+	}
+	if len(product.Review) != 1 || product.Review[0].Type != "Review" {
+		t.Errorf("expected review type Review, got %v", product.Review)
+	}
+	if product.Review[0].Author == nil || product.Review[0].Author.Type != "Person" {
+		t.Errorf("expected author type Person, got %v", product.Review[0].Author)
+	}
+	if product.Review[0].ReviewRating == nil || product.Review[0].ReviewRating.Type != "Rating" {
+		t.Errorf("expected rating type Rating, got %v", product.Review[0].ReviewRating)
+	}
+}
+
+func TestProduct_EnsureDefaults_NilSafe(t *testing.T) {
+	product := &Product{}
+	product.ensureDefaults()
+
+	if product.Context != "https://schema.org" {
+		t.Errorf("expected context schema.org, got %s", product.Context)
+	}
+	if product.Type != "Product" {
+		t.Errorf("expected type Product, got %s", product.Type)
+	}
+}
+
+func TestBrand_EnsureDefaults(t *testing.T) {
+	b := &Brand{}
+	b.ensureDefaults()
+	if b.Type != "Brand" {
+		t.Errorf("expected Brand type, got %s", b.Type)
+	}
+}
+
+func TestOffer_EnsureDefaults(t *testing.T) {
+	o := &Offer{}
+	o.ensureDefaults()
+	if o.Type != "Offer" {
+		t.Errorf("expected Offer type, got %s", o.Type)
+	}
+}
+
+func TestAggregateRating_EnsureDefaults(t *testing.T) {
+	a := &AggregateRating{}
+	a.ensureDefaults()
+	if a.Type != "AggregateRating" {
+		t.Errorf("expected AggregateRating type, got %s", a.Type)
+	}
+}
+
+func TestReview_EnsureDefaults_WithNested(t *testing.T) {
+	r := &Review{
+		Author:       &Person{},
+		ReviewRating: &Rating{},
+	}
+	r.ensureDefaults()
+
+	if r.Type != "Review" {
+		t.Errorf("expected Review type, got %s", r.Type)
+	}
+	if r.Author.Type != "Person" {
+		t.Errorf("expected Author type Person, got %s", r.Author.Type)
+	}
+	if r.ReviewRating.Type != "Rating" {
+		t.Errorf("expected Rating type Rating, got %s", r.ReviewRating.Type)
+	}
+}
+
+func TestRating_EnsureDefaults(t *testing.T) {
+	r := &Rating{}
+	r.ensureDefaults()
+	if r.Type != "Rating" {
+		t.Errorf("expected Rating type, got %s", r.Type)
+	}
+}
+
+func TestProduct_ToGoHTMLJsonLd(t *testing.T) {
+	product := NewProduct(
+		"Test Product",
+		"Sample product description",
+		[]string{"https://example.com/image.jpg"},
+		"SKU123",
+		&Brand{Name: "TestBrand"},
+		&Offer{Price: "99.99", PriceCurrency: "USD"},
+		"Electronics",
+		nil,
+		nil,
+	)
+
+	html, err := product.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == "" {
+		t.Error("expected non-empty HTML output")
+	}
+}

--- a/schemaorg/sitenavigationelement_test.go
+++ b/schemaorg/sitenavigationelement_test.go
@@ -2,6 +2,8 @@ package schemaorg
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -101,5 +103,253 @@ func TestFromSitemapFile(t *testing.T) {
 	// Compare the loaded struct with the expected data
 	if !reflect.DeepEqual(&siteNav, sampleSiteNav) {
 		t.Errorf("Loaded SiteNavigationElement does not match expected struct.\nExpected:\n%+v\nGot:\n%+v", sampleSiteNav, &siteNav)
+	}
+}
+
+func TestSiteNavigationElement_EnsureDefaults(t *testing.T) {
+	sne := &SiteNavigationElement{
+		ItemList: &ItemList{},
+	}
+	sne.ensureDefaults()
+
+	if sne.Context != "https://schema.org" {
+		t.Errorf("expected context to be schema.org, got %s", sne.Context)
+	}
+	if sne.Type != "SiteNavigationElement" {
+		t.Errorf("expected type to be SiteNavigationElement, got %s", sne.Type)
+	}
+	if sne.Position != 1 {
+		t.Errorf("expected default position to be 1, got %d", sne.Position)
+	}
+	if sne.ItemList.Context != "https://schema.org" {
+		t.Errorf("expected itemList context to be schema.org, got %s", sne.ItemList.Context)
+	}
+	if sne.ItemList.Type != "ItemList" {
+		t.Errorf("expected itemList type to be ItemList, got %s", sne.ItemList.Type)
+	}
+}
+
+func TestNewSiteNavigationElement_SetsDefaults(t *testing.T) {
+	itemList := &ItemList{ItemListElement: []ItemListElement{{Name: "Home", URL: "https://example.com", Position: 1}}}
+	sne := NewSiteNavigationElement("Main Nav", "https://example.com", 2, "main", itemList)
+
+	if sne.Context != "https://schema.org" {
+		t.Errorf("expected context to be schema.org, got %s", sne.Context)
+	}
+	if sne.Type != "SiteNavigationElement" {
+		t.Errorf("expected type to be SiteNavigationElement, got %s", sne.Type)
+	}
+	if sne.Position != 2 {
+		t.Errorf("expected position 2, got %d", sne.Position)
+	}
+	if sne.ItemList == nil || sne.ItemList.Type != "ItemList" {
+		t.Errorf("expected ItemList with type ItemList")
+	}
+}
+
+func TestNewItemList_SetsDefaults(t *testing.T) {
+	items := []ItemListElement{{Name: "Home", URL: "https://example.com", Position: 1}}
+	list := NewItemList(items)
+
+	if list.Context != "https://schema.org" {
+		t.Errorf("expected context to be schema.org")
+	}
+	if list.Type != "ItemList" {
+		t.Errorf("expected type to be ItemList")
+	}
+	if len(list.ItemListElement) != 1 {
+		t.Errorf("expected one item, got %d", len(list.ItemListElement))
+	}
+}
+
+func TestSiteNavigationElement_ToGoHTMLJsonLd(t *testing.T) {
+	sne := NewSiteNavigationElementWithItemList("Main Nav", "https://example.com", []ItemListElement{
+		NewItemListElement("Home", "https://example.com", 1),
+	})
+
+	html, err := sne.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == "" {
+		t.Errorf("expected non-empty HTML output")
+	}
+}
+
+func TestSiteNavigationElement_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *SiteNavigationElement
+		expected []string
+	}{
+		{
+			name: "valid input",
+			input: NewSiteNavigationElementWithItemList("Nav", "https://example.com", []ItemListElement{
+				NewItemListElement("Home", "https://example.com", 1),
+			}),
+			expected: nil,
+		},
+		{
+			name:  "missing name and url",
+			input: &SiteNavigationElement{},
+			expected: []string{
+				"missing recommended field: name",
+				"missing recommended field: url",
+				"ItemList should contain at least one item",
+			},
+		},
+		{
+			name: "missing fields in item list element",
+			input: &SiteNavigationElement{
+				Name: "Nav", URL: "https://example.com",
+				ItemList: &ItemList{
+					ItemListElement: []ItemListElement{
+						{}, // all fields missing
+					},
+				},
+			},
+			expected: []string{
+				"missing name in ItemListElement at position 1",
+				"missing url in ItemListElement at position 1",
+				"missing position in ItemListElement at index 0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := tt.input.Validate()
+			if len(warnings) != len(tt.expected) {
+				t.Errorf("expected %d warnings, got %d: %v", len(tt.expected), len(warnings), warnings)
+				return
+			}
+			for _, expected := range tt.expected {
+				found := false
+				for _, got := range warnings {
+					if got == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected warning %q not found in %v", expected, warnings)
+				}
+			}
+		})
+	}
+}
+
+func TestToSitemapFile_Errors(t *testing.T) {
+	sne := &SiteNavigationElement{}
+
+	// ItemList is nil
+	err := sne.ToSitemapFile("dummy.xml")
+	if err == nil || err.Error() != "ItemList is nil, cannot generate sitemap" {
+		t.Errorf("expected error for nil ItemList, got %v", err)
+	}
+
+	// XML marshal error (simulate by injecting invalid data if needed)
+
+	// File write error (read-only path)
+	err = sne.ToSitemapFile("/tmp/tmpoai36nm9") // from previous execution
+	if err == nil {
+		t.Errorf("expected write error, got nil")
+	}
+}
+
+func TestFromSitemapFile_Errors(t *testing.T) {
+	sne := &SiteNavigationElement{}
+
+	// File not found
+	err := sne.FromSitemapFile("/nonexistent/path/to/file.xml") // from previous execution
+	if err == nil {
+		t.Errorf("expected error for nonexistent file")
+	}
+
+	// Invalid XML
+	tempFile, _ := os.CreateTemp("", "invalid-*.xml")
+	defer os.Remove(tempFile.Name())
+	tempFile.WriteString("<<< invalid xml >>>")
+	tempFile.Close()
+
+	err = sne.FromSitemapFile(tempFile.Name())
+	if err == nil {
+		t.Errorf("expected error for invalid XML")
+	}
+}
+
+func TestToSitemapFile_WriteFileError(t *testing.T) {
+	original := writeFile
+	defer func() { writeFile = original }()
+
+	writeFile = func(name string, data []byte, perm os.FileMode) error {
+		return fmt.Errorf("mock write error")
+	}
+
+	sne := &SiteNavigationElement{
+		ItemList: &ItemList{
+			ItemListElement: []ItemListElement{
+				{URL: "https://example.com"},
+			},
+		},
+	}
+	err := sne.ToSitemapFile("dummy.xml")
+	if err == nil || err.Error() != "error writing XML file: mock write error" {
+		t.Errorf("expected mock write error, got %v", err)
+	}
+}
+
+func TestToSitemapFile_MarshalIndentError(t *testing.T) {
+	// Backup and restore original marshalIndent
+	originalMarshal := marshalIndent
+	defer func() { marshalIndent = originalMarshal }()
+
+	// Simulate marshal error
+	marshalIndent = func(v any, prefix, indent string) ([]byte, error) {
+		return nil, fmt.Errorf("simulated marshal error")
+	}
+
+	sne := &SiteNavigationElement{
+		ItemList: &ItemList{
+			ItemListElement: []ItemListElement{
+				{URL: "https://example.com"},
+			},
+		},
+	}
+
+	err := sne.ToSitemapFile("dummy.xml")
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if err.Error() != "error marshaling sitemap to XML: simulated marshal error" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+type faultyReader struct{}
+
+func (faultyReader) Read(p []byte) (int, error) {
+	return 0, fmt.Errorf("simulated read error")
+}
+func (faultyReader) Close() error { return nil }
+
+func TestFromSitemapFile_ReadError(t *testing.T) {
+	originalOpen := openFile
+	defer func() { openFile = originalOpen }()
+
+	openFile = func(name string) (io.ReadCloser, error) {
+		return faultyReader{}, nil
+	}
+
+	sne := &SiteNavigationElement{}
+	err := sne.FromSitemapFile("dummy.xml")
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expected := "could not read XML file: simulated read error"
+	if err.Error() != expected {
+		t.Errorf("expected error %q, got %q", expected, err.Error())
 	}
 }

--- a/schemaorg/sitenavigationelement_test.go
+++ b/schemaorg/sitenavigationelement_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -224,13 +225,7 @@ func TestSiteNavigationElement_Validate(t *testing.T) {
 				return
 			}
 			for _, expected := range tt.expected {
-				found := false
-				for _, got := range warnings {
-					if got == expected {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(warnings, expected)
 				if !found {
 					t.Errorf("expected warning %q not found in %v", expected, warnings)
 				}
@@ -267,9 +262,15 @@ func TestFromSitemapFile_Errors(t *testing.T) {
 	}
 
 	// Invalid XML
-	tempFile, _ := os.CreateTemp("", "invalid-*.xml")
+	tempFile, err := os.CreateTemp("", "invalid-*.xml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
 	defer os.Remove(tempFile.Name())
-	tempFile.WriteString("<<< invalid xml >>>")
+	_, err = tempFile.WriteString("<<< invalid xml >>>")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
 	tempFile.Close()
 
 	err = sne.FromSitemapFile(tempFile.Name())

--- a/schemaorg/types.go
+++ b/schemaorg/types.go
@@ -1,15 +1,5 @@
 package schemaorg
 
-import (
-	"context"
-	"fmt"
-	"html/template"
-	"log"
-
-	"github.com/a-h/templ"
-	"github.com/indaco/teseo"
-)
-
 // Common type definitions used across multiple JSON-LD entities
 
 // ContactPoint represents a Schema.org ContactPoint object
@@ -34,73 +24,6 @@ func (img *ImageObject) ensureDefaults() {
 	if img.Type == "" {
 		img.Type = "ImageObject"
 	}
-}
-
-// Organization represents a Schema.org Organization object
-// For more details about the meaning of the properties see: https://schema.org/Organization
-type Organization struct {
-	Context       string         `json:"@context"`
-	Type          string         `json:"@type"`
-	Name          string         `json:"name,omitempty"`
-	URL           string         `json:"url,omitempty"`
-	Logo          *ImageObject   `json:"logo,omitempty"`
-	ContactPoints []ContactPoint `json:"contactPoint,omitempty"`
-	SameAs        []string       `json:"sameAs,omitempty"`
-}
-
-func (org *Organization) ensureDefaults() {
-	if org.Context == "" {
-		org.Context = "https://schema.org"
-	}
-
-	if org.Type == "" {
-		org.Type = "Organization"
-	}
-
-	if org.Logo != nil {
-		org.Logo.ensureDefaults()
-	}
-}
-
-// ToJsonLd converts the Organization struct to a JSON-LD `templ.Component`.
-func (org *Organization) ToJsonLd() templ.Component {
-	org.ensureDefaults()
-	id := fmt.Sprintf("%s-%s", "org", teseo.GenerateUniqueKey())
-	return templ.JSONScript(id, org).WithType("application/ld+json")
-}
-
-// ToGoHTMLJsonLd renders the Organization struct as `template.HTML` value for Go's `html/template`.
-func (org *Organization) ToGoHTMLJsonLd() (template.HTML, error) {
-	// Create the templ component.
-	templComponent := org.ToJsonLd()
-
-	// Render the templ component to a `template.HTML` value.
-	html, err := templ.ToGoHTML(context.Background(), templComponent)
-	if err != nil {
-		log.Fatalf("failed to convert to html: %v", err)
-	}
-
-	return html, nil
-}
-
-// Person represents a Schema.org Person object
-// For more details about the meaning of the properties see: https://schema.org/Person
-type Person struct {
-	Context     string         `json:"@context"`
-	Type        string         `json:"@type"`
-	Name        string         `json:"name,omitempty"`
-	URL         string         `json:"url,omitempty"`
-	Email       string         `json:"email,omitempty"`
-	Image       *ImageObject   `json:"image,omitempty"`
-	JobTitle    string         `json:"jobTitle,omitempty"`
-	WorksFor    *Organization  `json:"worksFor,omitempty"`
-	SameAs      []string       `json:"sameAs,omitempty"`
-	Gender      string         `json:"gender,omitempty"`
-	BirthDate   string         `json:"birthDate,omitempty"`
-	Nationality string         `json:"nationality,omitempty"`
-	Telephone   string         `json:"telephone,omitempty"`
-	Address     *PostalAddress `json:"address,omitempty"`
-	Affiliation *Organization  `json:"affiliation,omitempty"`
 }
 
 // ListItem represents a Schema.org ListItem object

--- a/schemaorg/validate.go
+++ b/schemaorg/validate.go
@@ -1,0 +1,15 @@
+package schemaorg
+
+import "log"
+
+// SchemaValidator defines an interface for types that can be validated for schema.org compliance.
+type SchemaValidator interface {
+	// Validate returns a slice of warning messages for missing recommended or required fields.
+	Validate() []string
+}
+
+func LogValidationWarnings(v SchemaValidator) {
+	for _, warning := range v.Validate() {
+		log.Printf("schema warning: %s", warning)
+	}
+}

--- a/schemaorg/validate_test.go
+++ b/schemaorg/validate_test.go
@@ -1,0 +1,69 @@
+package schemaorg
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+// mockValidator is a helper for simulating a SchemaValidator
+type mockValidator struct {
+	warnings []string
+}
+
+func (m *mockValidator) Validate() []string {
+	return m.warnings
+}
+
+func TestLogValidationWarnings(t *testing.T) {
+	tests := []struct {
+		name      string
+		validator SchemaValidator
+		expected  []string
+	}{
+		{
+			name:      "no warnings",
+			validator: &mockValidator{warnings: []string{}},
+			expected:  nil,
+		},
+		{
+			name:      "single warning",
+			validator: &mockValidator{warnings: []string{"missing headline"}},
+			expected:  []string{"schema warning: missing headline"},
+		},
+		{
+			name: "multiple warnings",
+			validator: &mockValidator{warnings: []string{
+				"missing headline", "missing image", "missing datePublished",
+			}},
+			expected: []string{
+				"schema warning: missing headline",
+				"schema warning: missing image",
+				"schema warning: missing datePublished",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			log.SetOutput(&buf)
+			defer log.SetOutput(nil) // restore default output
+
+			LogValidationWarnings(tt.validator)
+
+			output := buf.String()
+			for _, expected := range tt.expected {
+				if !strings.Contains(output, expected) {
+					t.Errorf("expected log to contain %q, but got: %q", expected, output)
+				}
+			}
+
+			// Optional: ensure nothing is logged when expected is nil
+			if len(tt.expected) == 0 && output != "" {
+				t.Errorf("expected no output, got: %q", output)
+			}
+		})
+	}
+}

--- a/schemaorg/webpage.go
+++ b/schemaorg/webpage.go
@@ -1,10 +1,8 @@
 package schemaorg
 
 import (
-	"context"
 	"fmt"
 	"html/template"
-	"log"
 
 	"github.com/a-h/templ"
 	"github.com/indaco/teseo"
@@ -102,6 +100,25 @@ func NewWebPage(url string, name string, headline string, description string, ab
 	return webpage
 }
 
+func (wp *WebPage) Validate() []string {
+	var warnings []string
+
+	if wp.URL == "" {
+		warnings = append(warnings, "missing recommended field: url")
+	}
+	if wp.Name == "" {
+		warnings = append(warnings, "missing recommended field: name")
+	}
+	if wp.Headline == "" {
+		warnings = append(warnings, "missing recommended field: headline")
+	}
+	if wp.Description == "" {
+		warnings = append(warnings, "missing recommended field: description")
+	}
+
+	return warnings
+}
+
 // ToJsonLd converts the WebPage struct to a JSON-LD `templ.Component`.
 func (wp *WebPage) ToJsonLd() templ.Component {
 	wp.ensureDefaults()
@@ -111,12 +128,7 @@ func (wp *WebPage) ToJsonLd() templ.Component {
 
 // ToGoHTMLJsonLd renders the WebSite struct as `template.HTML` value for Go's `html/template`.
 func (wp *WebPage) ToGoHTMLJsonLd() (template.HTML, error) {
-	html, err := templ.ToGoHTML(context.Background(), wp.ToJsonLd())
-	if err != nil {
-		log.Printf("failed to convert to html: %v", err)
-		return "", err
-	}
-	return html, nil
+	return teseo.RenderToHTML(wp.ToJsonLd())
 }
 
 func (wp *WebPage) ensureDefaults() {

--- a/schemaorg/webpage_test.go
+++ b/schemaorg/webpage_test.go
@@ -2,6 +2,7 @@ package schemaorg
 
 import (
 	"html/template"
+	"slices"
 	"testing"
 )
 
@@ -89,13 +90,7 @@ func TestWebPage_Validate_MissingFields(t *testing.T) {
 	}
 
 	for _, want := range expected {
-		found := false
-		for _, w := range got {
-			if w == want {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(got, want)
 		if !found {
 			t.Errorf("expected warning %q not found in %v", want, got)
 		}

--- a/schemaorg/webpage_test.go
+++ b/schemaorg/webpage_test.go
@@ -1,0 +1,103 @@
+package schemaorg
+
+import (
+	"html/template"
+	"testing"
+)
+
+func TestNewWebPage_SetsFieldsAndDefaults(t *testing.T) {
+	wp := NewWebPage(
+		"https://example.com",
+		"Example Page",
+		"Headline Here",
+		"Description here",
+		"About something",
+		"keywords, go, templ",
+		"en",
+		"Main site",
+		"2023-01-01",
+		"https://example.com/image.jpg",
+		"2023-01-01",
+		"2023-01-02",
+	)
+
+	if wp.Context != "https://schema.org" {
+		t.Errorf("expected default context to be schema.org, got %s", wp.Context)
+	}
+	if wp.Type != "WebPage" {
+		t.Errorf("expected default type to be WebPage, got %s", wp.Type)
+	}
+	if wp.URL != "https://example.com" {
+		t.Errorf("URL not set correctly")
+	}
+	if wp.Name != "Example Page" {
+		t.Errorf("Name not set correctly")
+	}
+	if wp.Headline != "Headline Here" {
+		t.Errorf("Headline not set correctly")
+	}
+}
+
+func TestWebPage_EnsureDefaults(t *testing.T) {
+	wp := &WebPage{}
+	wp.ensureDefaults()
+
+	if wp.Context != "https://schema.org" {
+		t.Errorf("expected schema.org context, got %s", wp.Context)
+	}
+	if wp.Type != "WebPage" {
+		t.Errorf("expected type to be WebPage, got %s", wp.Type)
+	}
+}
+
+func TestWebPage_ToGoHTMLJsonLd(t *testing.T) {
+	wp := NewWebPage("https://test.com", "Test", "Headline", "Desc", "", "", "", "", "", "", "", "")
+	html, err := wp.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == template.HTML("") {
+		t.Errorf("expected non-empty HTML output")
+	}
+}
+
+func TestWebPage_Validate_AllGood(t *testing.T) {
+	wp := &WebPage{
+		URL:         "https://example.com",
+		Name:        "Example",
+		Headline:    "Headline",
+		Description: "Description",
+	}
+	warnings := wp.Validate()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestWebPage_Validate_MissingFields(t *testing.T) {
+	wp := &WebPage{}
+	got := wp.Validate()
+	expected := []string{
+		"missing recommended field: url",
+		"missing recommended field: name",
+		"missing recommended field: headline",
+		"missing recommended field: description",
+	}
+
+	if len(got) != len(expected) {
+		t.Errorf("expected %d warnings, got %d: %v", len(expected), len(got), got)
+	}
+
+	for _, want := range expected {
+		found := false
+		for _, w := range got {
+			if w == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected warning %q not found in %v", want, got)
+		}
+	}
+}

--- a/schemaorg/website.go
+++ b/schemaorg/website.go
@@ -90,6 +90,30 @@ func NewWebSite(url string, name string, alternateName string, description strin
 	return website
 }
 
+func (ws *WebSite) Validate() []string {
+	var warnings []string
+
+	if ws.URL == "" {
+		warnings = append(warnings, "missing recommended field: url")
+	}
+
+	if ws.Name == "" {
+		warnings = append(warnings, "missing recommended field: name")
+	}
+
+	if ws.Description == "" {
+		warnings = append(warnings, "missing recommended field: description")
+	}
+
+	if ws.PotentialAction != nil {
+		if ws.PotentialAction.Target == nil || ws.PotentialAction.Target.URLTemplate == "" {
+			warnings = append(warnings, "potentialAction.target.urlTemplate is recommended when potentialAction is set")
+		}
+	}
+
+	return warnings
+}
+
 // ToJsonLd converts the WebSite struct to a JSON-LD `templ.Component`.
 func (ws *WebSite) ToJsonLd() templ.Component {
 	ws.ensureDefaults()
@@ -99,12 +123,7 @@ func (ws *WebSite) ToJsonLd() templ.Component {
 
 // ToGoHTMLJsonLd renders the WebSite struct as `template.HTML` value for Go's `html/template`.
 func (ws *WebSite) ToGoHTMLJsonLd() (template.HTML, error) {
-	html, err := templ.ToGoHTML(context.Background(), ws.ToJsonLd())
-	if err != nil {
-		log.Printf("failed to convert to html: %v", err)
-		return "", err
-	}
-	return html, nil
+	return teseo.RenderToHTML(ws.ToJsonLd())
 }
 
 func (ws *WebSite) ensureDefaults() {
@@ -112,7 +131,7 @@ func (ws *WebSite) ensureDefaults() {
 		ws.Context = "https://schema.org"
 	}
 
-	if ws.Context == "" {
+	if ws.Type == "" {
 		ws.Type = "WebSite"
 	}
 

--- a/schemaorg/website.go
+++ b/schemaorg/website.go
@@ -1,10 +1,8 @@
 package schemaorg
 
 import (
-	"context"
 	"fmt"
 	"html/template"
-	"log"
 
 	"github.com/a-h/templ"
 	"github.com/indaco/teseo"

--- a/schemaorg/website_test.go
+++ b/schemaorg/website_test.go
@@ -2,6 +2,7 @@ package schemaorg
 
 import (
 	"html/template"
+	"slices"
 	"testing"
 )
 
@@ -87,13 +88,7 @@ func TestWebSite_Validate(t *testing.T) {
 				t.Errorf("expected %d warnings, got %d: %v", len(tt.expected), len(warnings), warnings)
 			}
 			for _, expected := range tt.expected {
-				found := false
-				for _, w := range warnings {
-					if w == expected {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(warnings, expected)
 				if !found {
 					t.Errorf("missing expected warning: %s", expected)
 				}

--- a/schemaorg/website_test.go
+++ b/schemaorg/website_test.go
@@ -1,0 +1,131 @@
+package schemaorg
+
+import (
+	"html/template"
+	"testing"
+)
+
+func TestNewWebSite_SetsDefaults(t *testing.T) {
+	ws := NewWebSite(
+		"https://example.com",
+		"Example Website",
+		"Alt Name",
+		"A description",
+		nil,
+	)
+
+	if ws.Context != "https://schema.org" {
+		t.Errorf("expected context to be schema.org, got %s", ws.Context)
+	}
+	if ws.Type != "WebSite" {
+		t.Errorf("expected type to be WebSite, got %s", ws.Type)
+	}
+	if ws.Name != "Example Website" || ws.URL != "https://example.com" {
+		t.Errorf("fields not set correctly")
+	}
+}
+
+func TestWebSite_ToGoHTMLJsonLd(t *testing.T) {
+	ws := NewWebSite("https://example.com", "Example", "", "", nil)
+	html, err := ws.ToGoHTMLJsonLd()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if html == template.HTML("") {
+		t.Errorf("expected non-empty HTML output")
+	}
+}
+
+func TestWebSite_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		ws       *WebSite
+		expected []string
+	}{
+		{
+			name: "valid website",
+			ws: &WebSite{
+				URL:         "https://example.com",
+				Name:        "My Site",
+				Description: "Nice site",
+			},
+			expected: nil,
+		},
+		{
+			name:     "missing all",
+			ws:       &WebSite{},
+			expected: []string{"missing recommended field: url", "missing recommended field: name", "missing recommended field: description"},
+		},
+		{
+			name: "potentialAction without target",
+			ws: &WebSite{
+				URL:             "https://example.com",
+				Name:            "My Site",
+				Description:     "Cool site",
+				PotentialAction: &Action{},
+			},
+			expected: []string{"potentialAction.target.urlTemplate is recommended when potentialAction is set"},
+		},
+		{
+			name: "potentialAction with empty target",
+			ws: &WebSite{
+				URL:         "https://example.com",
+				Name:        "My Site",
+				Description: "Cool site",
+				PotentialAction: &Action{
+					Target: &Target{},
+				},
+			},
+			expected: []string{"potentialAction.target.urlTemplate is recommended when potentialAction is set"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := tt.ws.Validate()
+			if len(warnings) != len(tt.expected) {
+				t.Errorf("expected %d warnings, got %d: %v", len(tt.expected), len(warnings), warnings)
+			}
+			for _, expected := range tt.expected {
+				found := false
+				for _, w := range warnings {
+					if w == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("missing expected warning: %s", expected)
+				}
+			}
+		})
+	}
+}
+
+func TestWebSite_EnsureDefaults_WithPotentialActionAndTarget(t *testing.T) {
+	// Arrange
+	target := &Target{}
+	action := &Action{
+		Target: target,
+	}
+	ws := &WebSite{
+		PotentialAction: action,
+	}
+
+	// Act
+	ws.ensureDefaults()
+
+	// Assert
+	if ws.Context != "https://schema.org" {
+		t.Errorf("expected context to be schema.org, got %s", ws.Context)
+	}
+	if ws.Type != "WebSite" {
+		t.Errorf("expected type to be WebSite, got %s", ws.Type)
+	}
+	if ws.PotentialAction.Type != "Action" {
+		t.Errorf("expected Action type to be Action, got %s", ws.PotentialAction.Type)
+	}
+	if ws.PotentialAction.Target.Type != "EntryPoint" {
+		t.Errorf("expected Target type to be EntryPoint, got %s", ws.PotentialAction.Target.Type)
+	}
+}

--- a/twittercard/twittercard.go
+++ b/twittercard/twittercard.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"html/template"
 	"io"
-	"log"
 
 	"github.com/a-h/templ"
 	"github.com/indaco/teseo"
@@ -23,6 +22,8 @@ const (
 	CardApp               TwitterCardType = "app"
 	CardPlayer            TwitterCardType = "player"
 )
+
+var WriteMetaTag = teseo.WriteMetaTag
 
 // TwitterCard contains information for generating Twitter Card meta tags.
 // For more details about the meaning of the properties see: https://developer.x.com/en/docs/x-for-websites/cards/overview/markup
@@ -278,7 +279,7 @@ func (tc *TwitterCard) ToMetaTags() templ.Component {
 		// Write each meta tag using the writeMetaTag helper
 		for _, tag := range tc.metaTags() {
 			if tag.content != "" {
-				if err := teseo.WriteMetaTag(w, tag.name, tag.content); err != nil {
+				if err := WriteMetaTag(w, tag.name, tag.content); err != nil {
 					return err
 				}
 			}
@@ -289,13 +290,7 @@ func (tc *TwitterCard) ToMetaTags() templ.Component {
 
 // ToGoHTMLMetaTags generates the HTML meta tags for the Twitter Card as `template.HTML` value for Go's html/template
 func (tc *TwitterCard) ToGoHTMLMetaTags() (template.HTML, error) {
-	html, err := templ.ToGoHTML(context.Background(), tc.ToMetaTags())
-	if err != nil {
-		log.Printf("failed to convert to html: %v", err)
-		return "", err
-	}
-
-	return html, nil
+	return teseo.RenderToHTML(tc.ToMetaTags())
 }
 
 // metaTag represents a single Twitter Card meta tag with a name and content.
@@ -314,34 +309,19 @@ func (tc *TwitterCard) metaTags() []metaTag {
 	}
 
 	if tc.Image != "" {
-		tags = append(tags, struct {
-			name    string
-			content string
-		}{"twitter:image", tc.Image})
+		tags = append(tags, metaTag{"twitter:image", tc.Image})
 	}
 	if tc.Site != "" {
-		tags = append(tags, struct {
-			name    string
-			content string
-		}{"twitter:site", tc.Site})
+		tags = append(tags, metaTag{"twitter:site", tc.Site})
 	}
 	if tc.Creator != "" && (tc.Card == CardSummary || tc.Card == CardSummaryLargeImage) {
-		tags = append(tags, struct {
-			name    string
-			content string
-		}{"twitter:creator", tc.Creator})
+		tags = append(tags, metaTag{"twitter:creator", tc.Creator})
 	}
 	if tc.AppID != "" && tc.Card == CardApp {
-		tags = append(tags, struct {
-			name    string
-			content string
-		}{"twitter:app:id:iphone", tc.AppID})
+		tags = append(tags, metaTag{"twitter:app:id:iphone", tc.AppID})
 	}
 	if tc.PlayerURL != "" && tc.Card == CardPlayer {
-		tags = append(tags, struct {
-			name    string
-			content string
-		}{"twitter:player", tc.PlayerURL})
+		tags = append(tags, metaTag{"twitter:player", tc.PlayerURL})
 	}
 
 	return tags


### PR DESCRIPTION
This PR introduces enhancements and fixes related to the Schema.org validation process within the project. 

**Changes Made:**
1. **HTML Rendering Refactor:**
   - Refactored the HTML rendering in the `TwitterCard` component using `RenderToHTML` for improved performance and maintainability.

2. **Struct Organization:**
   - Moved the `Organization` and `Person` structs to their respective files to enhance code organization and readability.

3. **Fixes:**
   - Addressed an issue in the `schemaorg/website` module by correcting a property in the `ensureDefaults` function, ensuring proper defaults are applied.

4. **New Features:**
   - Added validation methods for various Schema.org entities, allowing for better data integrity and validation checks.

5. **Continuous Integration:**
   - Introduced a GitHub Actions workflow for automated generation of release notes, streamlining the release process.
