### PR TITLE
New StringOrSlice type for schema properties that accept strings or arrays - ContactOption, ContactType

### DIFF
--- a/schemaorg/types.go
+++ b/schemaorg/types.go
@@ -1,15 +1,37 @@
 package schemaorg
 
+import (
+	"encoding/json"
+)
+
 // Common type definitions used across multiple JSON-LD entities
+
+type StringOrSlice []string
+
+func (s StringOrSlice) IsZero() bool {
+	return len(s) == 0 || (len(s) == 1 && s[0] == "")
+}
+
+// UnmarshalJSON handles both string and []string
+func (s StringOrSlice) MarshalJSON() ([]byte, error) {
+	if len(s) == 0 || (len(s) == 1 && s[0] == "") {
+		// Should never get here if IsZero is respected, but safe fallback:
+		return []byte("null"), nil
+	}
+	if len(s) == 1 {
+		return json.Marshal(s[0])
+	}
+	return json.Marshal([]string(s))
+}
 
 // ContactPoint represents a Schema.org ContactPoint object
 // For more details about the meaning of the properties see: https://schema.org/ContactPoint
 type ContactPoint struct {
-	Type              string `json:"@type"`
-	Telephone         string `json:"telephone,omitempty"`
-	ContactType       string `json:"contactType,omitempty"`
-	AreaServed        string `json:"areaServed,omitempty"`
-	AvailableLanguage string `json:"availableLanguage,omitempty"`
+	Type              string        `json:"@type"`
+	Telephone         string        `json:"telephone,omitempty"`
+	ContactType       string        `json:"contactType,omitempty"`
+	AreaServed        StringOrSlice `json:"areaServed,omitempty"`
+	AvailableLanguage string        `json:"availableLanguage,omitempty"`
 }
 
 // ImageObject represents a Schema.org ImageObject object

--- a/schemaorg/types.go
+++ b/schemaorg/types.go
@@ -30,6 +30,7 @@ type ContactPoint struct {
 	Type              string        `json:"@type"`
 	Telephone         string        `json:"telephone,omitempty"`
 	ContactType       string        `json:"contactType,omitempty"`
+	ContactOption     StringOrSlice `json:"contactOption,omitempty"`
 	AreaServed        StringOrSlice `json:"areaServed,omitempty"`
 	AvailableLanguage string        `json:"availableLanguage,omitempty"`
 }

--- a/schemaorg/types.go
+++ b/schemaorg/types.go
@@ -1,38 +1,99 @@
 package schemaorg
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"strings"
 )
 
 // Common type definitions used across multiple JSON-LD entities
 
-type StringOrSlice []string
+// StringList supports both a single string or a slice of strings in JSON,
+// and always trims input strings.
+type StringList []string
 
-func (s StringOrSlice) IsZero() bool {
+// IsZero reports whether the value is empty or contains only one empty string.
+func (s StringList) IsZero() bool {
 	return len(s) == 0 || (len(s) == 1 && s[0] == "")
 }
 
-// UnmarshalJSON handles both string and []string
-func (s StringOrSlice) MarshalJSON() ([]byte, error) {
-	if len(s) == 0 || (len(s) == 1 && s[0] == "") {
-		// Should never get here if IsZero is respected, but safe fallback:
+// MarshalJSON encodes the value as either a string or an array of strings.
+func (s StringList) MarshalJSON() ([]byte, error) {
+	switch len(s) {
+	case 0:
 		return []byte("null"), nil
-	}
-	if len(s) == 1 {
+	case 1:
+		if strings.TrimSpace(s[0]) == "" {
+			return []byte("null"), nil
+		}
 		return json.Marshal(s[0])
+	default:
+		return json.Marshal([]string(s))
 	}
-	return json.Marshal([]string(s))
+}
+
+// UnmarshalJSON accepts both string and []string, and trims all values.
+func (s *StringList) UnmarshalJSON(data []byte) error {
+	// Handle null
+	if bytes.Equal(data, []byte("null")) {
+		*s = nil
+		return nil
+	}
+
+	// Try single string
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*s = StringList{strings.TrimSpace(single)}
+		return nil
+	}
+
+	// Try slice of strings
+	var multi []string
+	if err := json.Unmarshal(data, &multi); err == nil {
+		trimmed := make([]string, 0, len(multi))
+		for _, v := range multi {
+			v = strings.TrimSpace(v)
+			if v != "" {
+				trimmed = append(trimmed, v)
+			}
+		}
+		*s = trimmed
+		return nil
+	}
+
+	return fmt.Errorf("StringList: invalid JSON input: %s", string(data))
+}
+
+// ToSlice returns a canonical []string value or nil if empty.
+func (s StringList) ToSlice() []string {
+	if s.IsZero() {
+		return nil
+	}
+	return s
+}
+
+// String returns a comma-separated string representation.
+func (s StringList) String() string {
+	switch len(s) {
+	case 0:
+		return ""
+	case 1:
+		return s[0]
+	default:
+		return strings.Join(s, ", ")
+	}
 }
 
 // ContactPoint represents a Schema.org ContactPoint object
 // For more details about the meaning of the properties see: https://schema.org/ContactPoint
 type ContactPoint struct {
-	Type              string        `json:"@type"`
-	Telephone         string        `json:"telephone,omitempty"`
-	ContactType       string        `json:"contactType,omitempty"`
-	ContactOption     StringOrSlice `json:"contactOption,omitempty"`
-	AreaServed        StringOrSlice `json:"areaServed,omitempty"`
-	AvailableLanguage string        `json:"availableLanguage,omitempty"`
+	Type              string     `json:"@type"`
+	Telephone         string     `json:"telephone,omitempty"`
+	ContactType       string     `json:"contactType,omitempty"`
+	ContactOption     StringList `json:"contactOption,omitempty"`
+	AreaServed        StringList `json:"areaServed,omitempty"`
+	AvailableLanguage string     `json:"availableLanguage,omitempty"`
 }
 
 // ImageObject represents a Schema.org ImageObject object

--- a/schemaorg/types_test.go
+++ b/schemaorg/types_test.go
@@ -1,0 +1,54 @@
+package schemaorg
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Struct that uses the custom StringOrSlice type
+type MyStruct struct {
+	AreaServed StringOrSlice `json:"areaServed,omitempty"`
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    MyStruct
+		expected string
+	}{
+
+		{
+			name:     "Non-empty slice",
+			input:    MyStruct{AreaServed: StringOrSlice{"hello", "world"}},
+			expected: `{"areaServed":["hello","world"]}`,
+		},
+		{
+			name:     "String",
+			input:    MyStruct{AreaServed: StringOrSlice{"hello"}},
+			expected: `{"areaServed":"hello"}`,
+		},
+		{
+			name:     "Empty slice (should be omitted)",
+			input:    MyStruct{AreaServed: StringOrSlice{}},
+			expected: `{}`,
+		},
+		{
+			name:     "Nil slice (should be omitted)",
+			input:    MyStruct{},
+			expected: `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error marshaling: %v", err)
+			}
+
+			if string(data) != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, data)
+			}
+		})
+	}
+}

--- a/schemaorg/types_test.go
+++ b/schemaorg/types_test.go
@@ -2,12 +2,62 @@ package schemaorg
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
-// Struct that uses the custom StringOrSlice type
+// Struct that uses the custom StringList type
 type MyStruct struct {
-	AreaServed StringOrSlice `json:"areaServed,omitempty"`
+	AreaServed StringList `json:"areaServed,omitempty"`
+}
+
+func TestStringList_IsZero(t *testing.T) {
+	tests := []struct {
+		name  string
+		input StringList
+		want  bool
+	}{
+		{"nil slice", nil, true},
+		{"empty slice", StringList{}, true},
+		{"single empty string", StringList{""}, true},
+		{"single non-empty", StringList{"x"}, false},
+		{"multiple values", StringList{"x", "y"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.IsZero()
+			if got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringList_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    StringList
+		expected string
+	}{
+		{"nil slice", nil, `null`},
+		{"empty slice", StringList{}, `null`},
+		{"slice with empty string", StringList{""}, `null`},
+		{"single value", StringList{"foo"}, `"foo"`},
+		{"multiple values", StringList{"foo", "bar"}, `["foo","bar"]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("MarshalJSON() error = %v", err)
+			}
+			if string(data) != tt.expected {
+				t.Errorf("MarshalJSON() = %s, want %s", data, tt.expected)
+			}
+		})
+	}
 }
 
 func TestUnmarshalJSON(t *testing.T) {
@@ -19,17 +69,17 @@ func TestUnmarshalJSON(t *testing.T) {
 
 		{
 			name:     "Non-empty slice",
-			input:    MyStruct{AreaServed: StringOrSlice{"hello", "world"}},
+			input:    MyStruct{AreaServed: StringList{"hello", "world"}},
 			expected: `{"areaServed":["hello","world"]}`,
 		},
 		{
 			name:     "String",
-			input:    MyStruct{AreaServed: StringOrSlice{"hello"}},
+			input:    MyStruct{AreaServed: StringList{"hello"}},
 			expected: `{"areaServed":"hello"}`,
 		},
 		{
 			name:     "Empty slice (should be omitted)",
-			input:    MyStruct{AreaServed: StringOrSlice{}},
+			input:    MyStruct{AreaServed: StringList{}},
 			expected: `{}`,
 		},
 		{
@@ -51,4 +101,96 @@ func TestUnmarshalJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStringList_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected StringList
+		wantErr  bool
+	}{
+		{"null input", `null`, nil, false},
+		{"empty string", `""`, StringList{""}, false},
+		{"trimmed string", `"  foo  "`, StringList{"foo"}, false},
+		{"single non-empty", `"bar"`, StringList{"bar"}, false},
+		{"empty array", `[]`, StringList{}, false},
+		{"array of strings", `["a", "b", "c"]`, StringList{"a", "b", "c"}, false},
+		{"array with spaces", `["  x  ", " y "]`, StringList{"x", "y"}, false},
+		{"array with empty values", `["", " "]`, StringList{}, false},
+		{"invalid type", `123`, nil, true},
+		{"invalid json", `{`, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got StringList
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !equalSlices(got, tt.expected) {
+				t.Errorf("UnmarshalJSON() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStringList_ToSlice(t *testing.T) {
+	tests := []struct {
+		name  string
+		input StringList
+		want  []string
+	}{
+		{"nil", nil, nil},
+		{"empty", StringList{}, nil},
+		{"single empty string", StringList{""}, nil},
+		{"non-empty", StringList{"a", "b"}, []string{"a", "b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.ToSlice()
+			if !equalSlices(got, tt.want) {
+				t.Errorf("ToSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringList_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		input StringList
+		want  string
+	}{
+		{"nil", nil, ""},
+		{"empty", StringList{}, ""},
+		{"single", StringList{"foo"}, "foo"},
+		{"multi", StringList{"a", "b", "c"}, "a, b, c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.String()
+			if got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if strings.TrimSpace(v) != strings.TrimSpace(b[i]) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Hi!

I've added `ContactType` to the `ContactPoint` struct, but noticed in the documentation that this property (and also `AreaServed`), can be a string or an array of strings (slice).

Did a little AI-guided development to resolve this, and added tests. 

This is actually my first opensource PR, outside of work repositories - so hope I'm doing this right, and that the proposed change is acceptable!

Chris